### PR TITLE
Add support for BC4 and BC5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ include = [
     "src/astc.rs",
     "src/bc1.rs",
     "src/bc3.rs",
+    "src/bc4.rs",
+    "src/bc5.rs",
     "src/bc6h.rs",
     "src/bc7.rs",
     "src/etc1.rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ispc-texcomp"
 version = "0.1.2"
-authors = ["Daniel Hu <yimingdz@gmail.com>", "Graham Wihlidal <graham@wihlidal.ca>"]
+authors = ["Daniel Hu <yimingdz@gmail.com>", "Graham Wihlidal <graham@wihlidal.ca>", "Bruno Ancona <brunoanconasala@gmail.com>"]
 description = "Rust bindings for Intel's ISPC texture compressor."
 homepage = "https://github.com/Danielmelody/ispc-texcomp-rs"
 repository = "https://github.com/Danielmelody/ispc-texcomp-rs"

--- a/src/bc4.rs
+++ b/src/bc4.rs
@@ -1,0 +1,46 @@
+use crate::bindings::kernel;
+use crate::RgbaSurface;
+
+#[inline(always)]
+pub fn calc_output_size(width: u32, height: u32) -> usize {
+    // BC4 uses 8 bytes to store each 4×4 block, giving it an average data rate of 0.5 bytes per pixel.
+    let block_count = crate::cal_block_count(width, height, 4, 4) as usize;
+    block_count * 8
+}
+
+pub fn compress_blocks(surface: &RgbaSurface) -> Vec<u8> {
+    let output_size = calc_output_size(surface.width, surface.height);
+    let mut output = vec![0u8; output_size];
+    compress_blocks_into(surface, &mut output);
+    output
+}
+
+pub fn compress_blocks_into(surface: &RgbaSurface, blocks: &mut [u8]) {
+    assert_eq!(
+        blocks.len(),
+        calc_output_size(surface.width, surface.height)
+    );
+
+    let mut r_data = vec![0_u8; (surface.width * surface.height) as usize];
+    let pitch = (surface.width * 32 + 7) / 8;
+    let mut offset = 0_u32;
+
+    for y in 0..surface.height {
+        for x in 0..surface.width {
+            // Copy R byte over
+            r_data[offset as usize] = surface.data[(x * 4 + y * pitch) as usize];
+            offset += 1;
+        }
+    }
+
+    let mut surface = kernel::rgba_surface {
+        width: surface.width as i32,
+        height: surface.height as i32,
+        stride: (surface.stride / 4) as i32,
+        ptr: (&r_data).as_ptr() as *mut u8,
+    };
+
+    unsafe {
+        kernel::CompressBlocksBC4_ispc(&mut surface, blocks.as_mut_ptr());
+    }
+}

--- a/src/bc5.rs
+++ b/src/bc5.rs
@@ -1,0 +1,47 @@
+use crate::bindings::kernel;
+use crate::RgbaSurface;
+
+#[inline(always)]
+pub fn calc_output_size(width: u32, height: u32) -> usize {
+    // BC5 uses 16 bytes to store each 4×4 block, giving it an average data rate of 1 byte per pixel.
+    let block_count = crate::cal_block_count(width, height, 4, 4) as usize;
+    block_count * 16
+}
+
+pub fn compress_blocks(surface: &RgbaSurface) -> Vec<u8> {
+    let output_size = calc_output_size(surface.width, surface.height);
+    let mut output = vec![0u8; output_size];
+    compress_blocks_into(surface, &mut output);
+    output
+}
+
+pub fn compress_blocks_into(surface: &RgbaSurface, blocks: &mut [u8]) {
+    assert_eq!(
+        blocks.len(),
+        calc_output_size(surface.width, surface.height)
+    );
+
+    let mut rg_data = vec![0_u8; (surface.width * surface.height * 2) as usize];
+    let pitch = (surface.width * 32 + 7) / 8;
+    let mut offset = 0_u32;
+
+    for y in 0..surface.height {
+        for x in 0..surface.width {
+            // Copy R and G bytes over
+            rg_data[offset as usize] = surface.data[(x * 4 + y * pitch) as usize];
+            rg_data[(offset + 1) as usize] = surface.data[(x * 4 + y * pitch + 1) as usize];
+            offset += 2;
+        }
+    }
+
+    let mut surface = kernel::rgba_surface {
+        width: surface.width as i32,
+        height: surface.height as i32,
+        stride: (surface.stride / 2) as i32,
+        ptr: (&rg_data).as_ptr() as *mut u8,
+    };
+
+    unsafe {
+        kernel::CompressBlocksBC5_ispc(&mut surface, blocks.as_mut_ptr());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod bindings {
 pub mod astc;
 pub mod bc1;
 pub mod bc3;
+pub mod bc4;
+pub mod bc5;
 pub mod bc6h;
 pub mod bc7;
 pub mod etc1;


### PR DESCRIPTION
Adds support for the BC4 and BC5 formats.

Copied from my PR at <https://github.com/gwihlidal/intel-tex-rs/pull/4>, seeing as that repo seems to be dead.